### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides Nostr capabilities to LLMs like Claude.
 
+<a href="https://glama.ai/mcp/servers/@AustinKelsay/nostr-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AustinKelsay/nostr-mcp-server/badge" alt="Nostr Server MCP server" />
+</a>
+
 https://github.com/user-attachments/assets/1d2d47d0-c61b-44e2-85be-5985d2a81c64
 
 ## Features
@@ -129,4 +133,4 @@ To modify or extend this server:
 
 1. Edit the `index.ts` file in the project root
 2. Run `npm run build` to compile
-3. Restart Claude for Desktop to pick up your changes 
+3. Restart Claude for Desktop to pick up your changes


### PR DESCRIPTION
This PR adds a badge for the [Nostr MCP Server](https://glama.ai/mcp/servers/@AustinKelsay/nostr-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@AustinKelsay/nostr-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AustinKelsay/nostr-mcp-server/badge" alt="Nostr Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.